### PR TITLE
ci: update webhook call to use OAuth token generation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,18 +40,29 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-  
+
   deploy:
     environment: production
     runs-on: ubuntu-latest
     needs: build-and-push-image
 
     env:
-      WEBHOOK_TOKEN: ${{secrets.WEBHOOK_TOKEN}}
-      WEBHOOK_ID: ${{secrets.WEBHOOK_ID}}
+      USERNAME: ${{ secrets.USERNAME }}
+      PASSWORD: ${{ secrets.PASSWORD }}
+      WEBHOOK_ID: ${{ secrets.WEBHOOK_ID }}
 
     steps:
-      - name: Call webhook
-        run: | 
-          curl -H "Authorization: Bearer ${{env.WEBHOOK_TOKEN}}" https://webhooks.modscleo4.dev.br/webhook/${{env.WEBHOOK_ID}}/call
-    
+      - name: 🔑 Get webhook token
+        run: |
+          export WEBHOOK_TOKEN=$(curl --request POST \
+            --url https://webhooks.modscleo4.dev.br/oauth/token \
+            --header 'Content-Type: application/x-www-form-urlencoded' \
+            --data grant_type=password \
+            --data username=$USERNAME \
+            --data password=$PASSWORD \
+            --data scope=call | jq -r .access_token)
+          echo "WEBHOOK_TOKEN=$WEBHOOK_TOKEN" >> $GITHUB_ENV
+
+      - name: 📞 Call webhook
+        run: |
+          curl -H "Authorization: Bearer $WEBHOOK_TOKEN" https://webhooks.modscleo4.dev.br/webhook/$WEBHOOK_ID/call


### PR DESCRIPTION
This pull request updates the webhook authentication process in the `.github/workflows/docker-build.yml` workflow. Instead of using a static token, it now securely retrieves a token via OAuth using a username and password, then uses the token to call the webhook.

## Changes

Authentication improvements:

* Changed the workflow to fetch the `WEBHOOK_TOKEN` dynamically using OAuth credentials (`USERNAME` and `PASSWORD`) instead of relying on a pre-existing secret token.
* Split the webhook call into two steps: first, obtaining the token, and then making the authenticated webhook call with the retrieved token.