### PR TITLE
feat: add guild-aware i18n system

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,7 +1,4 @@
-use bostil_core::{
-	backends::i18n::DiscordI18n,
-	collectors::{CommandCollector, ListenerCollector},
-};
+use bostil_core::collectors::{CommandCollector, ListenerCollector};
 use lazy_static::lazy_static;
 use reqwest::Client as HttpClient;
 use serenity::prelude::TypeMapKey;
@@ -24,12 +21,7 @@ impl TypeMapKey for HttpKey {
 
 pub mod modules;
 
-// use CUSTOM_BACKEND to i18n! macro
-i18n!(
-	"public/locales",
-	fallback = "en-US",
-	backend = DiscordI18n::new()
-);
+i18n!("public/locales", fallback = "en-US");
 
 lazy_static! {
 	pub static ref COMMAND_COLLECTOR: std::sync::Mutex<CommandCollector> =

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -5,25 +5,13 @@ use bostil_core::{
 	commands::CommandContext,
 	database::exports::{establish_connection, run_migrations},
 	listeners::ListenerKind,
-	runners::CommandResponse,
+	runners::{CommandResponse, ListenerResponse},
 	set_guild_context,
 };
-use serenity::{
-	all::{
-<<<<<<< HEAD
-		Command, CommandDataOption, GatewayIntents, GuildId, Interaction, Message, Ready, VoiceState,
-=======
-		Command, CommandDataOption, GatewayIntents, GuildId, Interaction, InteractionId, Message,
-		Ready, VoiceState,
->>>>>>> 30e715b (feat: set guild context for events and interactions)
-	},
-	async_trait,
-	builder::EditInteractionResponse,
-	client::Context,
-	framework::StandardFramework,
-	gateway::ActivityData,
-	prelude::EventHandler,
-	Client,
+use serenity::all::{
+	async_trait, builder::EditInteractionResponse, client::Context, framework::StandardFramework,
+	gateway::ActivityData, prelude::EventHandler, Client, Command, CommandDataOption, GatewayIntents,
+	GuildId, Interaction, InteractionId, Message, Ready, VoiceState,
 };
 use songbird::SerenityInit;
 use std::env;
@@ -40,6 +28,15 @@ impl EventHandler for Handler {
 	// ---------
 	async fn message(&self, ctx: Context, msg: Message) {
 		debug!("Received message from User: {:#?}", msg.author.name);
+		let guild_id = match msg.guild_id {
+			Some(guild_id) => guild_id,
+			None => {
+				debug!("Message is not from a guild, ignoring");
+				return;
+			}
+		};
+
+		set_guild_context!(guild_id);
 
 		let collector = match LISTENER_COLLECTOR.lock() {
 			Ok(collector) => collector.clone(),
@@ -58,18 +55,36 @@ impl EventHandler for Handler {
 		arguments.insert(ArgumentsLevel::User, Box::new(msg.author.clone()));
 		arguments.insert(ArgumentsLevel::ChannelId, Box::new(msg.channel_id.clone()));
 		arguments.insert(ArgumentsLevel::Message, Box::new(msg.clone()));
-		arguments.insert(ArgumentsLevel::InteractionId, Box::new(None::<u64>));
+		arguments.insert(
+			ArgumentsLevel::InteractionId,
+			Box::new(None::<InteractionId>),
+		);
 		arguments.insert(
 			ArgumentsLevel::Options,
 			Box::new(None::<Vec<CommandDataOption>>),
 		);
 
 		for listener in collector.filter_listeners(ListenerKind::Message) {
-			listener
+			match listener
 				.runner
 				.run(ArgumentsLevel::provide(&listener.arguments, &arguments))
 				.await
-				.ok();
+			{
+				Ok(response) => match response {
+					ListenerResponse::None => {}
+					ListenerResponse::String(content) => {
+						if let Err(why) = msg.channel_id.say(&ctx.http, content).await {
+							error!("Cannot send message: {}", why);
+						}
+					}
+					_ => {
+						warn!("Listener response type not handled");
+					}
+				},
+				Err(why) => {
+					error!("Cannot run listener: {}", why);
+				}
+			}
 		}
 	}
 

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6,10 +6,16 @@ use bostil_core::{
 	database::exports::{establish_connection, run_migrations},
 	listeners::ListenerKind,
 	runners::CommandResponse,
+	set_guild_context,
 };
 use serenity::{
 	all::{
+<<<<<<< HEAD
 		Command, CommandDataOption, GatewayIntents, GuildId, Interaction, Message, Ready, VoiceState,
+=======
+		Command, CommandDataOption, GatewayIntents, GuildId, Interaction, InteractionId, Message,
+		Ready, VoiceState,
+>>>>>>> 30e715b (feat: set guild context for events and interactions)
 	},
 	async_trait,
 	builder::EditInteractionResponse,
@@ -129,6 +135,15 @@ impl EventHandler for Handler {
 	async fn voice_state_update(&self, ctx: Context, old: Option<VoiceState>, new: VoiceState) {
 		let is_bot: bool = new.user_id.to_user(&ctx.http).await.unwrap().bot;
 		let has_connected: bool = new.channel_id.is_some() && old.is_none();
+		let guild_id = match new.guild_id {
+			Some(guild_id) => guild_id,
+			None => {
+				error!("Cannot get guild id from voice state");
+				return;
+			}
+		};
+
+		set_guild_context!(guild_id);
 
 		if has_connected && !is_bot {
 			debug!("User connected to voice channel: {:#?}", new.channel_id);
@@ -161,59 +176,6 @@ impl EventHandler for Handler {
 					"Received modal submit interaction from User: {:#?}",
 					submit.user.name
 				);
-
-				// let registered_interactions = get_modal_interactions();
-
-				// // custom_id is in the format: '<interaction_name>/<id>'
-				// match registered_interactions.iter().enumerate().find(|(_, i)| {
-				//     i.name
-				//         == submit
-				//             .clone()
-				//             .data
-				//             .custom_id
-				//             .split("/")
-				//             .collect::<Vec<&str>>()
-				//             .first()
-				//             .unwrap()
-				//             .to_string()
-				// }) {
-				//     Some((_, interaction)) => {
-				//         let Some(guild) = ({
-				//             let cloned_ctx = ctx.clone();
-				//             let guild_reference = cloned_ctx.cache.guild(submit.guild_id.unwrap());
-
-				//             match guild_reference {
-				//                 Some(guild) => Some(guild.clone()),
-				//                 None => None,
-				//             }
-				//         }) else {
-				//             error!("Cannot get guild from cache");
-				//             return;
-				//         };
-
-				//         interaction
-				//             .runner
-				//             .run(&ArgumentsLevel::provide(
-				//                 &interaction.arguments,
-				//                 &ctx,
-				//                 &guild,
-				//                 &submit.user,
-				//                 &submit.channel_id,
-				//                 None,
-				//                 Some(submit.id),
-				//                 Some(&submit.data),
-				//                 None,
-				//             ))
-				//             .await;
-				//     }
-
-				//     None => {
-				//         error!(
-				//             "Modal submit interaction {} not found",
-				//             submit.data.custom_id.split("/").collect::<Vec<&str>>()[0]
-				//         );
-				//     }
-				// };
 			}
 
 			Interaction::Command(command) => {
@@ -221,6 +183,15 @@ impl EventHandler for Handler {
 					"Received command \"{}\" interaction from User: {:#?}",
 					command.data.name, command.user.name
 				);
+				let guild_id = match command.guild_id {
+					Some(guild_id) => guild_id,
+					None => {
+						error!("Cannot get guild id from command interaction");
+						return;
+					}
+				};
+
+				set_guild_context!(guild_id);
 
 				// Defer the interaction and edit it later
 				match command.defer(&ctx.http.clone()).await {

--- a/app/src/modules/app/commands/language.rs
+++ b/app/src/modules/app/commands/language.rs
@@ -2,11 +2,11 @@ use bostil_core::{
 	arguments::{ArgumentsLevel, CommandFnArguments},
 	commands::{Command, CommandCategory, CommandContext},
 	database::exports::{establish_connection, Guild, LanguageEnum},
+	gt as t,
 	runners::{CommandResponse, CommandResult, CommandRunnerFn},
 };
 use diesel::result::Error::NotFound;
 use lazy_static::lazy_static;
-use rust_i18n::t;
 use serenity::{
 	all::{CommandDataOption, CommandOptionType, Guild as SerenityGuild},
 	async_trait,

--- a/app/src/modules/app/commands/radio/mod.rs
+++ b/app/src/modules/app/commands/radio/mod.rs
@@ -4,10 +4,10 @@ pub mod equalizers;
 use bostil_core::{
 	arguments::{ArgumentsLevel, CommandFnArguments},
 	commands::{Command, CommandCategory, CommandContext},
+	gt as t,
 	runners::{CommandResponse, CommandResult, CommandRunnerFn},
 };
 use lazy_static::lazy_static;
-use rust_i18n::t;
 use serenity::{
 	all::{CommandDataOption, CommandDataOptionValue, CommandOptionType, Guild, User},
 	async_trait,
@@ -151,7 +151,7 @@ pub async fn run<'a>(
 		return Ok(t!("commands.radio.bot_not_connected").to_string());
 	}
 
-	Ok(t!("commands.radio.reply", "radio_name" => radio.to_string()).to_string())
+	Ok(t!("commands.radio.reply", radio_name => radio.to_string()).to_string())
 }
 
 lazy_static! {

--- a/app/src/modules/app/commands/voice/leave.rs
+++ b/app/src/modules/app/commands/voice/leave.rs
@@ -1,10 +1,10 @@
 use bostil_core::{
 	arguments::{ArgumentsLevel, CommandFnArguments},
 	commands::{Command, CommandCategory, CommandContext},
+	gt as t,
 	runners::{CommandResponse, CommandResult, CommandRunnerFn},
 };
 use lazy_static::lazy_static;
-use rust_i18n::t;
 use serenity::{
 	async_trait,
 	builder::CreateCommand,

--- a/app/src/modules/app/listeners/chat/love.rs
+++ b/app/src/modules/app/listeners/chat/love.rs
@@ -1,10 +1,10 @@
 use bostil_core::{
 	arguments::{ArgumentsLevel, ListenerFnArguments},
+	gt as t,
 	listeners::{Listener, ListenerKind},
 	runners::{ListenerResponse, ListenerResult, ListenerRunnerFn},
 };
 use lazy_static::lazy_static;
-use rust_i18n::t;
 use serenity::{
 	all::{ChannelId, User, UserId},
 	async_trait,
@@ -45,31 +45,31 @@ impl ListenerRunnerFn for Love {
 		match USER_ID == user.id {
 			true => {
 				let message = COUNTER.with(|counter| {
-                    LAST_MESSAGE_TIME.with(|last_message_time| {
-                        let mut counter = counter.borrow_mut();
-                        let mut last_message_time = last_message_time.borrow_mut();
-                        let now = std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs() as u32;
+					LAST_MESSAGE_TIME.with(|last_message_time| {
+						let mut counter = counter.borrow_mut();
+						let mut last_message_time = last_message_time.borrow_mut();
+						let now = std::time::SystemTime::now()
+							.duration_since(std::time::UNIX_EPOCH)
+							.unwrap()
+							.as_secs() as u32;
 
-                        if now - *last_message_time < 5 {
-                            *last_message_time = now;
+						if now - *last_message_time < 5 {
+							*last_message_time = now;
 
-                            return None.into();
-                        } else {
-                            *last_message_time = now;
-                            *counter += 1;
+							return None.into();
+						} else {
+							*last_message_time = now;
+							*counter += 1;
 
-                            if *counter == 1 {
-                                return t!("interactions.chat.love.reply", "user_id" => user.id).into();
-                            }
+							if *counter == 1 {
+								return t!("interactions.chat.love.reply", user_id => user.id).into();
+							}
 
-                            return t!("interactions.chat.love.reply_counter", "counter" => *counter, "user_id" => user.id)
+							return t!("interactions.chat.love.reply_counter", counter => *counter, user_id => user.id)
                                 .into();
-                        }
-                    })
-                });
+						}
+					})
+				});
 
 				match message {
 					Some(message) => match channel.say(&ctx.http, message).await {

--- a/app/src/modules/app/listeners/voice/join_channel.rs
+++ b/app/src/modules/app/listeners/voice/join_channel.rs
@@ -1,5 +1,7 @@
-use bostil_core::database::exports::{establish_connection, User};
-use rust_i18n::t;
+use bostil_core::{
+	database::exports::{establish_connection, User},
+	gt as t,
+};
 use serenity::all::{ChannelId, Context, UserId};
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/app/src/modules/core/actions/voice.rs
+++ b/app/src/modules/core/actions/voice.rs
@@ -1,5 +1,4 @@
-use rust_i18n::t;
-
+use bostil_core::gt as t;
 use serenity::framework::standard::CommandResult;
 use serenity::model::prelude::{Guild, UserId};
 use serenity::prelude::Context;

--- a/app/src/modules/core/helpers/database.rs
+++ b/app/src/modules/core/helpers/database.rs
@@ -2,17 +2,14 @@ use diesel::{pg::PgConnection, Connection};
 use diesel_migrations::{embed_migrations, EmbeddedMigrations};
 use dotenvy::dotenv;
 
-// TODO: implementar algum jeito para que cada servidor tenha seu próprio idioma e não alterar o idioma de todos os servidores
-i18n!("public/locales", fallback = "en-US");
-
 pub fn establish_connection() -> PgConnection {
-  use std::env;
+	use std::env;
 
-  dotenv().ok();
+	dotenv().ok();
 
-  let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
-  PgConnection::establish(&database_url)
-    .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
+	let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+	PgConnection::establish(&database_url)
+		.unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
 }
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations");

--- a/core/src/backends/i18n.rs
+++ b/core/src/backends/i18n.rs
@@ -46,7 +46,6 @@ fn get_guild_language(guild_id: GuildId) -> Language {
 		}
 	}
 
-	// Not in cache, query database
 	let language = {
 		let connection = &mut establish_connection();
 		match Guild::get_by_id(connection, GuildIdWrapper(guild_id)) {
@@ -55,7 +54,6 @@ fn get_guild_language(guild_id: GuildId) -> Language {
 		}
 	};
 
-	// Update cache
 	if let Ok(mut cache) = GUILD_LANGUAGE_CACHE.lock() {
 		cache.insert(guild_id, language);
 	}

--- a/core/src/backends/i18n.rs
+++ b/core/src/backends/i18n.rs
@@ -1,42 +1,105 @@
-use rust_i18n::Backend;
+//! Guild-aware internationalization system
+//!
+//! This module provides macros and utilities to handle translations
+//! based on the current Discord guild's language preference stored in the database.
+
+use crate::database::exports::{
+	establish_connection, Guild, GuildIdWrapper, LanguageEnum as Language,
+};
+use rust_i18n::t;
+use serenity::all::GuildId;
 use std::collections::HashMap;
+use std::sync::{Mutex, RwLock};
 
-pub struct DiscordI18n {
-	trs: HashMap<String, HashMap<String, String>>,
-}
+/// Thread-safe storage for current guild context
+static CURRENT_GUILD_ID: RwLock<Option<GuildId>> = RwLock::new(None);
 
-impl DiscordI18n {
-	pub fn new() -> Self {
-		// get from files in "app/public/locales" or "public/locales"
-		let files = std::fs::read_dir("public/locales")
-			.or_else(|_| std::fs::read_dir("app/public/locales"))
-			.expect("Failed to read locales directory");
-		let trs = serde_yaml::from_str::<HashMap<String, HashMap<String, String>>>(
-			&files
-				.filter_map(|entry| {
-					entry.ok().and_then(|e| {
-						if e.path().extension()?.to_str()? == "yaml" {
-							std::fs::read_to_string(e.path()).ok()
-						} else {
-							None
-						}
-					})
-				})
-				.collect::<Vec<String>>()
-				.join("\n"),
-		)
-		.unwrap();
+/// Cache for guild languages to avoid repeated database queries
+static GUILD_LANGUAGE_CACHE: std::sync::LazyLock<Mutex<HashMap<GuildId, Language>>> =
+	std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
-		DiscordI18n { trs }
+/// Sets the current guild context for translations
+pub fn set_current_guild(guild_id: GuildId) {
+	if let Ok(mut current) = CURRENT_GUILD_ID.write() {
+		*current = Some(guild_id);
 	}
 }
 
-impl Backend for DiscordI18n {
-	fn available_locales(&self) -> Vec<&str> {
-		return self.trs.keys().map(|k| k.as_str()).collect();
+/// Clears the current guild context
+pub fn clear_current_guild() {
+	if let Ok(mut current) = CURRENT_GUILD_ID.write() {
+		*current = None;
+	}
+}
+
+/// Gets the current guild ID from context
+fn get_current_guild() -> Option<GuildId> {
+	CURRENT_GUILD_ID.read().ok()?.clone()
+}
+
+/// Gets the language for a specific guild, with caching
+fn get_guild_language(guild_id: GuildId) -> Language {
+	// Try to get from cache first
+	if let Ok(cache) = GUILD_LANGUAGE_CACHE.lock() {
+		if let Some(language) = cache.get(&guild_id) {
+			return *language;
+		}
 	}
 
-	fn translate(&self, locale: &str, key: &str) -> Option<&str> {
-		return self.trs.get(locale)?.get(key).map(|k| k.as_str());
+	// Not in cache, query database
+	let language = {
+		let connection = &mut establish_connection();
+		match Guild::get_by_id(connection, GuildIdWrapper(guild_id)) {
+			Some(guild) => guild.language,
+			None => Language::En, // Default to English if not found
+		}
+	};
+
+	// Update cache
+	if let Ok(mut cache) = GUILD_LANGUAGE_CACHE.lock() {
+		cache.insert(guild_id, language);
+	}
+
+	language
+}
+
+/// Clears the language cache for a specific guild
+pub fn invalidate_guild_language_cache(guild_id: GuildId) {
+	if let Ok(mut cache) = GUILD_LANGUAGE_CACHE.lock() {
+		cache.remove(&guild_id);
+	}
+}
+
+/// Clears the entire language cache
+pub fn clear_language_cache() {
+	if let Ok(mut cache) = GUILD_LANGUAGE_CACHE.lock() {
+		cache.clear();
+	}
+}
+
+/// Guild-aware translation function
+///
+/// This function automatically uses the current guild's language preference
+/// or falls back to the provided locale or default language.
+#[allow(dead_code)]
+pub fn translate_for_guild(
+	key: &str,
+	locale: Option<&str>,
+	args: Option<&[(&str, &dyn std::fmt::Display)]>,
+) -> String {
+	let target_locale = match get_current_guild() {
+		Some(guild_id) => get_guild_language(guild_id).to_string(),
+		None => locale.unwrap_or("en-US").to_string(),
+	};
+
+	match args {
+		Some(args) => {
+			let mut result = t!(key, locale = &target_locale).to_string();
+			for (placeholder, value) in args {
+				result = result.replace(&format!("%{{{}}}", placeholder), &value.to_string());
+			}
+			result
+		}
+		None => t!(key, locale = &target_locale).to_string(),
 	}
 }

--- a/core/src/database/entities/mod.rs
+++ b/core/src/database/entities/mod.rs
@@ -83,9 +83,17 @@ where
 	}
 }
 
+// enables GuildIdWrapper to be used in places where GuildId is expected
 impl Into<GuildId> for GuildIdWrapper {
 	fn into(self) -> GuildId {
 		self.0
+	}
+}
+
+// enables GuildId to be used in places where GuildIdWrapper is expected
+impl Into<GuildIdWrapper> for GuildId {
+	fn into(self) -> GuildIdWrapper {
+		GuildIdWrapper(self)
 	}
 }
 

--- a/core/src/database/mod.rs
+++ b/core/src/database/mod.rs
@@ -4,6 +4,6 @@ mod models;
 
 pub mod exports {
 	pub use super::connector::{establish_connection, run_migrations};
-	pub use super::entities::exports::Language as LanguageEnum;
+	pub use super::entities::exports::{GuildIdWrapper, Language as LanguageEnum};
 	pub use super::models::exports::*;
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,5 @@
+use rust_i18n::i18n;
+
 extern crate proc_macro;
 
 pub mod arguments;
@@ -11,3 +13,8 @@ pub mod integrations;
 pub mod listeners;
 pub mod runners;
 pub mod schema;
+
+#[macro_use]
+pub mod macros;
+
+i18n!("../app/public/locales", fallback = "en-US");

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -84,6 +84,6 @@ macro_rules! gt {
 #[macro_export]
 macro_rules! set_guild_context {
 	($guild_id:expr) => {
-		$crate::i18n::set_current_guild($guild_id);
+		$crate::backends::i18n::set_current_guild($guild_id);
 	};
 }

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -1,0 +1,89 @@
+//! Macros for guild-aware internationalization
+
+/// Guild-aware translation macro
+///
+/// This macro works like the standard `t!` macro but automatically uses
+/// the current guild's language preference from the database.
+///
+/// # Examples
+///
+/// ```rust
+/// use bostil_core::gt;
+///
+/// // Simple translation
+/// let message = gt!("commands.ping.response");
+///
+/// // Translation with arguments
+/// let message = gt!("commands.language.reply", language_name => "English");
+///
+/// // Translation with explicit locale fallback
+/// let message = gt!("commands.ping.response", locale = "pt-BR");
+/// ```
+#[macro_export]
+macro_rules! gt {
+    // Simple case: gt!("key")
+    ($key:expr) => {
+        $crate::backends::i18n::translate_for_guild($key, None, None)
+    };
+
+    // With locale fallback: gt!("key", locale = "en-US")
+    ($key:expr, locale = $locale:expr) => {
+        $crate::backends::i18n::translate_for_guild($key, Some($locale), None)
+    };
+
+    // With single argument: gt!("key", arg => value)
+    ($key:expr, $arg:ident => $value:expr) => {
+        $crate::backends::i18n::translate_for_guild(
+            $key,
+            None,
+            Some(&[(stringify!($arg), &$value)])
+        )
+    };
+
+    // With single argument and locale: gt!("key", locale = "en-US", arg => value)
+    ($key:expr, locale = $locale:expr, $arg:ident => $value:expr) => {
+        $crate::backends::i18n::translate_for_guild(
+            $key,
+            Some($locale),
+            Some(&[(stringify!($arg), &$value)])
+        )
+    };
+
+    // With multiple arguments: gt!("key", arg1 => value1, arg2 => value2)
+    ($key:expr, $($arg:ident => $value:expr),+) => {
+        $crate::backends::i18n::translate_for_guild(
+            $key,
+            None,
+            Some(&[$(( stringify!($arg), &$value )),+])
+        )
+    };
+
+    // With multiple arguments and locale: gt!("key", locale = "en-US", arg1 => value1, arg2 => value2)
+    ($key:expr, locale = $locale:expr, $($arg:ident => $value:expr),+) => {
+        $crate::backends::i18n::translate_for_guild(
+            $key,
+            Some($locale),
+            Some(&[$(( stringify!($arg), &$value )),+])
+        )
+    };
+}
+
+/// Sets the current guild context for translations
+///
+/// This should be called at the beginning of command execution
+/// to ensure translations use the correct guild language.
+///
+/// # Example
+///
+/// ```rust
+/// use bostil_core::set_guild_context;
+/// use serenity::all::GuildId;
+///
+/// set_guild_context!(GuildId::new(123456789));
+/// ```
+#[macro_export]
+macro_rules! set_guild_context {
+	($guild_id:expr) => {
+		$crate::i18n::set_current_guild($guild_id);
+	};
+}


### PR DESCRIPTION
Changes:
* Implement a translation system that uses the current Discord guild's language preference from the database. 
* Add macros for guild-aware translations and context management. 
* Refactor usages to use the new `gt!` macro instead of `rust_i18n::t`. 
* Add caching for guild language lookups and conversion traits for GuildId/GuildIdWrapper.